### PR TITLE
Install halide libs into $RISCV, Don't exclude reshape tests

### DIFF
--- a/scripts/build-tools.sh
+++ b/scripts/build-tools.sh
@@ -24,7 +24,7 @@ set -o pipefail
 (cd llvm-project/build && make -j16 install)
 
 # Build Halide
-(cd Halide && make -j16 distrib PREFIX=$RISCV)
+(cd Halide && make -j16 install PREFIX=$RISCV)
 
 # Install python dependencies
 python3 -m pip install numpy protobuf pytest

--- a/scripts/test_onnx_backend.py
+++ b/scripts/test_onnx_backend.py
@@ -23,7 +23,6 @@ backend_test.exclude(r'test_[a-z,_]*rnn_[a-z,_]*')
 # No support for reshaping yet
 backend_test.exclude(r'test_(operator_|)expand_[a-z,_]*')
 backend_test.exclude(r'test_(operator_|)tile_[a-z,_]*')
-backend_test.exclude(r'test_reshape_[a-z,_]*')
 backend_test.exclude(r'test_PixelShuffle[a-z,_]*')
 
 # TODO support these


### PR DESCRIPTION
* Change "make distrib" to "make install" for Halide
* We now have reshape support